### PR TITLE
socialite authentication integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,18 @@ This project demonstrates how to set up a Laravel 12 application with Laravel Pa
 - PHP and Composer installed.
 - Basic knowledge of Laravel and web development.
 
-### Steps to Install Laravel Passport
+### Steps to Configure Laravel Passport
 
 1. **Clone the Repository:**
    ```
-   git clone <repository-url>
-   cd <repository-directory>
+      git clone <repository-url>
+      cd <repository-directory>
    ```
+   put the project into the local webserver directory (laragon/www/ or similar) with the names `fe` and `laravel`
 
-2. **Install laravel:**
+2. **Install depedency:**
    ```
-      composer create-project laravel/laravel laravel   
+      composer install
    ```
 
 3. **Configure Environment Variables:**
@@ -162,6 +163,52 @@ This project demonstrates how to set up a Laravel 12 application with Laravel Pa
    - The system is designed for separate domains (backend and frontend).
    - Always use HTTPS in production to secure token transmission.
    - Refer to the Laravel and Passport documentation for more details if needed.
+
+# Laravel Socialite Authenctication (addition)
+
+## Role of Socialite
+   1. **Integration Tool**:
+   Socialite serves as a tool to integrate external platform APIs with your internal server.
+
+   2. **Complementing Laravel Passport**:
+   Even though many OAuth 2.0 flows are already supported by the provider platforms, this project still utilizes Laravel Passport to manage the OAuth 2.0 flow internally.
+
+## Prerequisites
+   1. **API Developer Credentials**:
+   Obtain developer API credentials for the account you wish to use for authentication.
+
+   2. **Registered Callback Page**:
+   Ensure that the callback page (redirect URI) is registered in your provider’s account settings.
+
+## Steps to Configure Laravel Socialite
+
+1. **Application Credentials**
+   Add the credentials obtained from the platform 
+   (e.g., from console.cloud.google.com) in your `.env` file:
+   ```
+   GOOGLE_CLIENT_ID=id_from_platform
+   GOOGLE_CLIENT_SECRET=secret_from_platform    
+   GOOGLE_REDIRECT_URI=http://laravel.org/google/callback
+   ```
+2. **Service Configuration**
+   Define the login behavior and the expected output after a successful login in your `config/services.php` file.
+3. **Redirect**
+   Sometimes, you may need to use the `with()` clause before redirecting to the platform's login page. For example, with Google, you might add `select_account` to force the user to choose an account and re-login.
+
+4. **Callback**
+   Set up the callback behavior to handle authentication. For instance, once you receive the user’s email details, perform a check to ensure the user is registered in your system.
+
+##  Potential Future Enhancements
+   -**PKCE with OTP Integration**:
+      Implement PKCE along with an OTP mechanism, where after generating the authorization code, the user receives an OTP through a messaging app for additional verification.
+
+   -**Dynamic Callback Pages**:
+      Define callback pages based on the client ID so that the callback page can be more dynamic and cater to multiple clients.
+
+   -**Direct Management by the Provider**:
+      Explore possibilities where some aspects of management are handled directly by the provider platform.
+
+ 
 
 ## License
 This project is licensed under the MIT License.

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Str;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Laravel\Socialite\Facades\Socialite;
+
+
+class AuthController extends Controller
+{
+    function LoginPage()
+    {
+        return view('auth.login');
+    }
+
+    function RedirectToPlatform(Request $request)
+    {
+        $platform = $request->validate([
+            'platform'    => 'sometimes|in:' . env("LOGIN_PLATFORM", "google")
+        ]);
+
+
+
+        if (!empty($platform)) {
+            if ($request->platform == "google") {
+                return Socialite::driver($platform['platform'])
+                    ->with(['prompt' => 'select_account'])
+                    ->redirect();
+            } elseif ($request->platform == "facebook" || $request->platform == "github") {
+                return Socialite::driver($platform['platform'])
+                    ->redirect();
+            }
+        } else {
+            return $this->LoginPage();
+        }
+    }
+
+    function HandleGoogleCallback(Request $request)
+    {
+        $email = Socialite::driver('google')->user()->email;
+        // dd($email);
+        // Cek apakah email sudah ada di database
+        $user = User::where('email', $email)->first();
+
+        if ($user) {
+            // Jika user ditemukan, langsung login
+            Auth::login($user);
+            return redirect()->intended('/auth/redirect');
+        } else {
+            return redirect("login")->withErrors(['email' => 'check your Email or contact your administrator ']);
+        }
+    }
+
+    function HandleFacebookCallback(Request $request)
+    {
+        $email = Socialite::driver('facebook')->user()->getEmail();
+        // dd($email);
+        // Cek apakah email sudah ada di database
+        $user = User::where('email', $email)->first();
+
+        if ($user) {
+            // Jika user ditemukan, langsung login
+            Auth::login($user);
+            return redirect()->intended('/auth/redirect');
+        } else {
+            return redirect("login")->withErrors(['email' => 'check your Email or contact your administrator ']);
+        }
+    }
+
+
+    function HandleGithubCallback(Request $request)
+    {
+        $email = Socialite::driver('Github')->user()->getEmail();
+        // dd($email);
+        // Cek apakah email sudah ada di database   
+        // dd($email);
+        $user = User::where('email', $email)->first();
+
+        if ($user) {
+            // Jika user ditemukan, langsung login
+            Auth::login($user);
+            return redirect()->intended('/auth/redirect');
+        } else {
+            return redirect("login")->withErrors(['email' => 'check your Email or contact your administrator ']);
+        }
+    }
+
+    function LocalLoginSubmit(Request $request)
+    {
+        $credentials = $request->validate([
+            'email'    => 'required',
+            'password' => 'required',
+        ]);
+
+        if (Auth::attempt($credentials)) {
+
+            return redirect()->intended('/auth/redirect');
+        }
+
+        return back()->withErrors([
+            'email' => 'Email atau password salah',
+        ]);
+    }
+
+    function LocalRedirect(Request $request)
+    {
+        // Simpan nilai state dan code_verifier ke session (disimpan di database atau storage session lain)
+        $state = Str::random(10);
+        $codeVerifier = Str::random(128);
+        $request->session()->put('state', $state);
+        $request->session()->put('code_verifier', $codeVerifier);
+
+        // Buat code_challenge dari code_verifier
+        $codeChallenge = strtr(
+            rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='),
+            '+/',
+            '-_'
+        );
+
+        // Siapkan parameter query untuk redirect ke /oauth/authorize
+        $query = http_build_query([
+            'client_id'             => '1',
+            'redirect_uri'          => 'http://fe.org/callback.php', // Callback URL di FE.org
+            'response_type'         => 'code',
+            'scope'                 => '', // sesuaikan scope jika perlu
+            'state'                 => $state,
+            'code_challenge'        => $codeChallenge,
+            'code_challenge_method' => 'S256',
+            'prompt'                => 'consent', // Memaksa login, bisa diubah jika tidak diinginkan
+        ]);
+
+        return redirect(url('/oauth/authorize?' . $query));
+    }
+
+    function  LocalCallback(Request $request)
+    {
+
+        // Ambil nilai state dan code_verifier yang disimpan di session
+        $storedState = $request->session()->pull("state");
+        $codeVerifier = $request->session()->pull("code_verifier");
+        // Log::info($storedState . "  |=|     " . $request->state . "   0-0     " . $codeVerifier . "  |=|     " . $request->code);
+
+        // Validasi state untuk mencegah CSRF
+        throw_unless(
+            strlen($storedState) > 0 && $storedState === $request->state,
+            \InvalidArgumentException::class,
+            'Invalid state value.'
+        );
+
+        // Tukar authorization code dengan token dari endpoint OAuth token
+        $response = Http::asForm()->post(url('/oauth/token'), [
+            'grant_type'    => 'authorization_code',
+            'client_id'     => '1',
+            'redirect_uri'  => 'http://fe.org/callback.php',
+            'code_verifier' => $codeVerifier,
+            'code'          => $request->code, // gunakan authorization code yang benar
+        ]);
+        // return $response;
+        // Jika terjadi error pada response token, tangani dengan mengembalikan error message
+        if (!$response->successful()) {
+            // dd($response);
+            return response()->json(['error' => 'Token exchange failed'], $response->status());
+        }
+
+        $response = $response->json();
+        // protected string $name,
+        // protected ?string $value = null,
+        // int|string|\DateTimeInterface $expire = 0,
+        // ?string $path = '/',
+        // protected ?string $domain = null,
+        // protected ?bool $secure = null,
+        // protected bool $httpOnly = true,
+        // private bool $raw = false,
+        // ?string $sameSite = self::SAMESITE_LAX,
+        // private bool $partitioned = false,
+        // return $response;
+        $accessToken  = rawurldecode($response['access_token']);
+        $refreshToken = rawurldecode($response['refresh_token']);
+        $expiresIn    = env("PASSPORT_REFRESH") * 60; // second
+
+        // Redirect ke FE dengan parameter token yang sudah "mentah"
+        return redirect("http://fe.org/callback.php?access_token={$accessToken}&refresh_token={$refreshToken}&expires_in={$expiresIn}");
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -29,6 +29,7 @@ class AppServiceProvider extends ServiceProvider
     {
 
         Passport::hashClientSecrets();
+
         // PASSPORT_REFRESH
         //         PASSPORT_ACCESS=1
         // PASSPORT_REFRESH=3

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -9,6 +9,7 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/passport": "^12.0",
+        "laravel/socialite": "^5.18",
         "laravel/tinker": "^2.10.1"
     },
     "require-dev": {

--- a/laravel/composer.lock
+++ b/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19af9ccf282ef1cca2155b8977933990",
+    "content-hash": "69fbb67949dc5df87c855726b5203b5d",
     "packages": [
         {
             "name": "brick/math",
@@ -1596,6 +1596,78 @@
             "time": "2025-02-11T15:03:05+00:00"
         },
         {
+            "name": "laravel/socialite",
+            "version": "v5.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/socialite.git",
+                "reference": "7809dc71250e074cd42970f0f803f2cddc04c5de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/7809dc71250e074cd42970f0f803f2cddc04c5de",
+                "reference": "7809dc71250e074cd42970f0f803f2cddc04c5de",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "league/oauth1-client": "^1.11",
+                "php": "^7.2|^8.0",
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.0|^9.3|^10.4|^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Socialite": "Laravel\\Socialite\\Facades\\Socialite"
+                    },
+                    "providers": [
+                        "Laravel\\Socialite\\SocialiteServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Socialite\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel wrapper around OAuth 1 & OAuth 2 libraries.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "laravel",
+                "oauth"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/socialite/issues",
+                "source": "https://github.com/laravel/socialite"
+            },
+            "time": "2025-02-11T13:38:19+00:00"
+        },
+        {
             "name": "laravel/tinker",
             "version": "v2.10.1",
             "source": {
@@ -2228,6 +2300,82 @@
                 }
             ],
             "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "league/oauth1-client",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth1-client.git",
+                "reference": "f9c94b088837eb1aae1ad7c4f23eb65cc6993055"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth1-client/zipball/f9c94b088837eb1aae1ad7c4f23eb65cc6993055",
+                "reference": "f9c94b088837eb1aae1ad7c4f23eb65cc6993055",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "guzzlehttp/psr7": "^1.7|^2.0",
+                "php": ">=7.1||>=8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "mockery/mockery": "^1.3.3",
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5||9.5"
+            },
+            "suggest": {
+                "ext-simplexml": "For decoding XML-based responses."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth1\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Corlett",
+                    "email": "bencorlett@me.com",
+                    "homepage": "http://www.webcomm.com.au",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OAuth 1.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "bitbucket",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth1",
+                "single sign on",
+                "trello",
+                "tumblr",
+                "twitter"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth1-client/issues",
+                "source": "https://github.com/thephpleague/oauth1-client/tree/v1.11.0"
+            },
+            "time": "2024-12-10T19:59:05+00:00"
         },
         {
             "name": "league/oauth2-server",

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -13,10 +13,227 @@ return [
     | a conventional file to locate the various service credentials.
     |
     */
+    'google' => [
+        /*
+     * ---------------------------------------------------------------------
+     * Mandatory Parameters (Wajib)
+     * ---------------------------------------------------------------------
+     */
 
-    'postmark' => [
-        'token' => env('POSTMARK_TOKEN'),
+        // Client ID dari Google, didapatkan dari Google Cloud Console.
+        'client_id'     => env('GOOGLE_CLIENT_ID'),
+
+        // Client Secret dari Google, digunakan untuk memverifikasi aplikasi Anda.
+        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+
+        // Redirect URI: URL callback yang telah didaftarkan di Google Cloud Console.
+        'redirect'      => env('GOOGLE_REDIRECT_URI'),
+
+        /*
+     * ---------------------------------------------------------------------
+     * Scope
+     * ---------------------------------------------------------------------
+     * Scope menentukan izin apa saja yang diminta.
+     * - 'openid' wajib jika menggunakan OpenID Connect (mendapatkan ID token).
+     * - 'email' untuk mendapatkan alamat email pengguna.
+     * - 'profile' untuk mendapatkan data profil dasar (opsional, tambahkan jika diperlukan).
+     */
+        'scope'         => ['email', 'openid'], // Tambahkan 'profile' jika ingin data profil lengkap.
+
+        /*
+     * ---------------------------------------------------------------------
+     * Optional Parameters (Opsional)
+     * ---------------------------------------------------------------------
+     * Parameter di bawah ini akan ditambahkan ke query string saat permintaan OAuth.
+     */
+        'options' => [
+            // prompt: Mengontrol tampilan halaman otorisasi.
+            // Nilai yang mungkin:
+            // - "none"    : Tidak menampilkan prompt (jika memungkinkan).
+            // - "consent" : Memaksa pengguna untuk menyetujui ulang.
+            // - "select_account" : Meminta pengguna memilih akun jika mereka memiliki beberapa akun.
+            // Contoh gabungan: "select_account consent" untuk kedua efek tersebut.
+            'prompt' => 'select_account consent',
+
+            // hd: Hosted Domain.
+            // Membatasi login hanya untuk akun dari domain tertentu, misalnya "example.com".
+            // Jika tidak ada pembatasan, Anda bisa menggunakan '*' atau tidak menyertakan parameter ini.
+            'hd' => env("APP_URL", "http://laravel.org"),
+
+            // access_type: Menentukan jenis akses.
+            // - "online"  : Akses online saja (tanpa refresh token).
+            // - "offline" : Menghasilkan refresh token agar aplikasi dapat mengakses data saat pengguna tidak aktif.
+            // Uncomment dan atur jika diperlukan:
+            // 'access_type' => 'offline',
+
+            // include_granted_scopes: Menentukan apakah scope yang sudah diberikan sebelumnya
+            // ikut dipertahankan atau tidak.
+            // - "true"  : Scope sebelumnya akan disertakan.
+            // - "false" : Scope tidak dipertahankan.
+            // Uncomment jika diperlukan:
+            // 'include_granted_scopes' => 'true',
+
+            // login_hint: Memberikan petunjuk kepada Google untuk menampilkan akun tertentu (misalnya email pengguna).
+            'login_hint' => 'user@example.com',
+
+            // response_type: Menentukan tipe respons.
+            // Biasanya "code" untuk authorization code flow.
+            // Secara default, Socialite menggunakan "code", jadi parameter ini biasanya tidak perlu diatur ulang.
+            // 'response_type' => 'code',
+
+            // max_age: Menentukan usia maksimum (dalam detik) dari sesi autentikasi yang diterima.
+            // Nilai 0 atau 1 berarti memaksa login ulang setiap kali, Anda bisa mengubah sesuai kebutuhan (misalnya, 3600 untuk satu jam).
+            'max_age' => 1,
+
+            // PKCE (Proof Key for Code Exchange)
+            // Jika Anda menerapkan PKCE, Anda harus mengirimkan code_challenge dan code_challenge_method.
+            // 'code_challenge'        => $challenge, // Nilai code challenge, dihasilkan dari code verifier dengan metode S256.
+            // 'code_challenge_method' => 'S256',      // Metode code challenge (biasanya 'S256').
+
+            // nonce: Nilai acak yang mengikat sesi pengguna dengan ID token.
+            // Pastikan setiap permintaan memiliki nilai nonce yang unik untuk keamanan.
+            // 'nonce' => 'unique_random_string',
+
+            // authuser: Digunakan jika pengguna memiliki beberapa akun Google dan ingin memilih akun tertentu.
+            // Nilai 0 biasanya untuk akun default.
+            // 'authuser' => 0,
+
+            // state: Parameter keamanan untuk mencegah serangan CSRF.
+            // Socialite biasanya mengelolanya secara otomatis, tetapi Anda bisa mengaturnya jika perlu.
+            // 'state' => 'custom_state_value',
+        ],
     ],
+
+    'facebook' => [
+        /*
+     * ------------------------------
+     *  Mandatory Parameters
+     * ------------------------------
+     */
+        'client_id'         => env('FACEBOOK_CLIENT_ID'),
+        // Facebook App ID, didapatkan dari Facebook Developer Portal.
+
+        'client_secret'     => env('FACEBOOK_CLIENT_SECRET'),
+        // Facebook App Secret, digunakan untuk memverifikasi aplikasi Anda.
+
+        'redirect'          => env('FACEBOOK_REDIRECT_URI'),
+        // URL callback yang akan dipanggil oleh Facebook setelah autentikasi.
+        // URL ini harus didaftarkan di bagian "Authorized Redirect URIs" di Facebook Developer.
+
+        'graph_api_version' => 'v12.0',
+        // Versi Graph API yang akan digunakan. Pastikan sesuai dengan versi yang aktif di Facebook Developer.
+
+        /*
+     * ------------------------------
+     *  Optional Parameters
+     * ------------------------------
+     */
+
+        'fields'            => 'name,email,picture',
+        // Field yang akan diminta dari profil pengguna.
+        // Misalnya, 'name,email,picture' untuk mendapatkan nama, email, dan foto profil.
+
+        'scopes'            => ['email', 'public_profile'],
+        // Izin (permissions) yang diminta dari pengguna.
+        // Contoh: 'email' untuk mendapatkan alamat email, 'public_profile' untuk data profil dasar.
+        // Anda bisa menambahkan scope tambahan seperti 'user_friends', 'user_birthday', dsb. sesuai kebutuhan.
+
+        // 'display'         => 'popup',
+        // Menentukan mode tampilan halaman login Facebook.
+        // Nilai umum: 'page' (default), 'popup', 'touch', 'wap'.
+        // Uncomment baris ini jika Anda ingin menggunakan tampilan popup.
+
+        // 'locale'          => 'en_US',
+        // Menentukan bahasa yang digunakan pada halaman login.
+        // Contoh: 'en_US' untuk Bahasa Inggris Amerika, 'id_ID' untuk Bahasa Indonesia.
+
+        // 'auth_type'       => 'rerequest',
+        // Digunakan untuk mengatur tipe autentikasi tambahan:
+        // 'rerequest' memaksa permintaan ulang izin jika pengguna sebelumnya menolak.
+        // 'reauthenticate' memaksa pengguna untuk login ulang.
+        // Uncomment dan atur nilai ini jika diperlukan.
+
+        /*
+     * ------------------------------
+     *  Parameter Tambahan (Optional via with())
+     * ------------------------------
+     *
+     * Anda juga dapat menambahkan parameter kustom tambahan ketika memanggil driver Facebook
+     * menggunakan method with(), misalnya:
+     *
+     * return Socialite::driver('facebook')
+     *     ->with(['display' => 'popup', 'locale' => 'en_US'])
+     *     ->redirect();
+     *
+     * Parameter tambahan lainnya yang didukung oleh Facebook juga dapat ditambahkan jika diperlukan.
+     */
+    ],
+
+    'github' => [
+        /*
+     * ---------------------------------------------------------------------
+     * Mandatory Parameters
+     * ---------------------------------------------------------------------
+     */
+
+        // Client ID dari GitHub
+        // Diperoleh dari GitHub Developer Settings, merupakan identifikasi unik aplikasi Anda.
+        'client_id'     => env('GITHUB_CLIENT_ID'),
+
+        // Client Secret dari GitHub
+        // Kunci rahasia aplikasi, digunakan untuk verifikasi dan penukaran kode otorisasi dengan token.
+        'client_secret' => env('GITHUB_CLIENT_SECRET'),
+
+        // Redirect URI (Callback URL)
+        // URL ini adalah tempat GitHub akan mengarahkan kembali pengguna setelah proses otentikasi.
+        // Pastikan URL ini terdaftar di Authorized Redirect URIs pada pengaturan aplikasi GitHub.
+        'redirect'      => env('GITHUB_REDIRECT_URI'),
+
+        /*
+     * ---------------------------------------------------------------------
+     * Optional Parameters
+     * ---------------------------------------------------------------------
+     */
+
+        // Scopes
+        // Menentukan izin (permissions) yang diminta dari pengguna.
+        // Contoh umum:
+        // - 'read:user' untuk mengakses data profil publik.
+        // - 'user:email' untuk mendapatkan alamat email.
+        // Anda dapat menambahkan scope tambahan sesuai kebutuhan.
+        'scopes'        => ['read:user', 'user:email'],
+
+        // State
+        // Digunakan untuk mencegah serangan CSRF (Cross-Site Request Forgery).
+        // Anda bisa menyetel nilai statis di sini atau menghasilkannya secara dinamis di controller.
+        'state'         => env('GITHUB_OAUTH_STATE', null),
+
+        // Stateless
+        // Menentukan apakah alur OAuth dilakukan tanpa menyimpan state (misalnya, untuk API atau aplikasi mobile).
+        // Jika diset ke true, Socialite tidak akan menyimpan state di session.
+        'stateless'     => true,
+
+        /*
+     * ---------------------------------------------------------------------
+     * Additional Custom Parameters (for reference)
+     * ---------------------------------------------------------------------
+     *
+     * Parameter tambahan biasanya tidak disetel langsung di config, melainkan
+     * dikirim secara dinamis melalui method ->with() di controller.
+     *
+     * Misalnya, jika Anda ingin mencegah signup baru via GitHub, Anda bisa mengirim:
+     *   ->with(['allow_signup' => 'false'])
+     *
+     * Jika ingin mengatur parameter ini secara default, Anda dapat menyimpannya di sini:
+     */
+
+        // Allow Signup
+        // Mengatur apakah tampilan otorisasi GitHub mengizinkan pengguna mendaftar akun baru.
+        // Nilai 'true' (default) memungkinkan signup, sedangkan 'false' menonaktifkannya.
+        'allow_signup'  => env('GITHUB_ALLOW_SIGNUP', 'true'),
+    ],
+
+
 
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),

--- a/laravel/resources/views/auth/login.blade.php
+++ b/laravel/resources/views/auth/login.blade.php
@@ -1,30 +1,198 @@
 <!DOCTYPE html>
 <html lang="id">
-<head>
-    <meta charset="UTF-8">
-    <title>Login - pcke.org</title>
-</head>
-<body>
-    <?php
 
-    ?>
-    <h2>Login ke pcke.org</h2>
-    <form method="POST" action="{{ route('login.submit') }}">
-        @csrf
-        <label>Email:</label>
-        <input type="text" name="email" required>
-        <br>
-        <label>Password:</label>
-        <input type="password" name="password" required>
-        <br>
-        <button type="submit">Login</button>
-    </form>
-    @if ($errors->any())
-      <div style="color:red;">
-          @foreach ($errors->all() as $error)
-              <p>{{ $error }}</p>
-          @endforeach
+<head>
+  <meta charset="UTF-8">
+  <title>Login - pcke.org</title>
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Font Awesome CDN -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+    integrity="sha512-Fo3rlrZj/kMVqzD9r5eIu8z/6x8DfxeXpF7+un00ay8x/99/z5+LzQABl/7Em3P75jRj2uZj3YsEdt/3Y/RiOA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <style>
+    body {
+      background: #f5f5f5;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .login-wrapper {
+      display: flex;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      overflow: hidden;
+      max-width: 900px;
+      width: 100%;
+    }
+
+    /* Kolom slider */
+    .login-image {
+      flex: 1;
+      display: none;
+      /* Hidden on small screens */
+    }
+
+    @media (min-width: 768px) {
+      .login-image {
+        display: block;
+      }
+    }
+
+    /* Kolom form login */
+    .login-form {
+      flex: 1;
+      padding: 30px;
+    }
+
+    h2 {
+      font-weight: 600;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      padding: 10px 20px;
+      font-size: 16px;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+      transition: background-color 0.3s;
+      border: none;
+      cursor: pointer;
+      width: 100%;
+      justify-content: center;
+      margin-bottom: 10px;
+    }
+
+    .btn-icon {
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+      background-size: contain;
+      background-position: center;
+      background-repeat: no-repeat;
+      margin-right: 10px;
+    }
+
+    /* Tombol Google */
+    .btn-google {
+      background-color: #540d6e;
+    }
+
+    .btn-google:hover {
+      background-color: rgb(210, 210, 210);
+      color: #000;
+    }
+
+    .btn-google .btn-icon {
+      background-image: url('https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/24px-Google_%22G%22_logo.svg.png');
+    }
+
+    /* Tombol Facebook */
+    .btn-facebook {
+      background-color: #ee4266;
+    }
+
+    .btn-facebook:hover {
+      background-color: rgb(210, 210, 210);
+      color: #000;
+    }
+
+    .btn-facebook .btn-icon {
+      background-image: url('https://upload.wikimedia.org/wikipedia/commons/0/05/Facebook_Logo_(2019).png');
+    }
+
+    /* Tombol Facebook */
+    .btn-github {
+      background-color:#ffd23f;
+    }
+
+    .btn-github:hover {
+      background-color: rgb(210, 210, 210);
+      color: #000;
+    }
+
+    .btn-github .btn-icon {
+      background-image: url('https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/GitHub_Invertocat_Logo.svg/240px-GitHub_Invertocat_Logo.svg.png');
+    }
+  </style>
+</head>
+
+<body>
+  <div class="login-wrapper">
+    <!-- Kolom Slider di Background Kiri -->
+    <div class="login-image">
+      <div id="carouselBackground" class="carousel slide h-100" data-bs-ride="carousel" data-bs-interval="3000">
+        <div class="carousel-inner h-100">
+          <div class="carousel-item active h-100">
+            <img src="https://st.depositphotos.com/17620692/58435/v/450/depositphotos_584355608-stock-illustration-abstract-colorful-blue-red-yellow.jpghttps://i.pinimg.com/736x/5b/64/99/5b6499cc2b325a7cc556c4d61f811357.jpghttps://i.pinimg.com/736x/5b/64/99/5b6499cc2b325a7cc556c4d61f811357.jpg" class="d-block w-100 h-100" alt="Slide 1" style="object-fit: cover;">
+          </div>
+          <div class="carousel-item h-100">
+            <img src="https://www.pixelstalk.net/wp-content/uploads/images6/Abstract-Wallpaper-4K-Wallpaper-HD.png" class="d-block w-100 h-100" alt="Slide 2" style="object-fit: cover;">
+          </div>
+          <div class="carousel-item h-100">
+            <img src="https://cdn.pixabay.com/photo/2016/05/22/19/15/background-1409028_640.png" class="d-block w-100 h-100" alt="Slide 3" style="object-fit: cover;">
+          </div>
+        </div>
       </div>
-    @endif
+    </div>
+
+    <!-- Kolom Form Login -->
+    <div class="login-form">
+      <h2 class="mb-4 text-center">Login ke pcke.org</h2>
+      <!-- Form Login Lokal -->
+      <form method="POST" action="{{ route('login.submit') }}">
+        @csrf
+        <div class="mb-3">
+          <label for="email" class="form-label">Email:</label>
+          <input type="text" class="form-control" id="email" name="email" required>
+        </div>
+        <div class="mb-3">
+          <label for="password" class="form-label">Password:</label>
+          <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-secondary">Login</button>
+      </form>
+
+      <hr>
+      <p class="text-center">Atau login dengan:</p>
+
+      <!-- Tombol Login Sosial -->
+      <div>
+        <a href="{{ route('platform.redirect') }}?platform=google" class="btn btn-google">
+          <span class="btn-icon"></span>
+          Login with Google
+        </a>
+        <a href="{{ route('platform.redirect') }}?platform=facebook" class="btn btn-facebook">
+          <span class="btn-icon"></span>
+          Login with Facebook
+        </a>
+        <a href="{{ route('platform.redirect') }}?platform=github" class="btn btn-github">
+          <span class="btn-icon"></span>
+          Login with Github
+        </a>
+      </div>
+
+      <!-- Tampilkan Error jika ada -->
+      @if ($errors->any())
+      <div class="alert alert-danger mt-3">
+        @foreach ($errors->all() as $error)
+        <p class="mb-1">{{ $error }}</p>
+        @endforeach
+      </div>
+      @endif
+    </div>
+  </div>
+
+  <!-- Bootstrap JS Bundle with Popper -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
+
 </html>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,130 +1,22 @@
 <?php
 
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\Request;
-use Illuminate\Log\Logger;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
+use App\Http\Controllers\AuthController;
 use Illuminate\Support\Facades\Route;
-// use InvalidArgumentException; // pastikan diimport
 
+Route::controller(AuthController::class)->group(function () {
+    // Routes yang tidak memerlukan middleware auth:web
+    Route::get('login', 'LoginPage')->name('login');
+    Route::post('auth/login/submit', 'LocalLoginSubmit')->name('login.submit');
+    Route::get('platform/redirect', 'RedirectToPlatform')->name('platform.redirect');
+    Route::get('google/callback', 'HandleGoogleCallback');
+    Route::get('facebook/callback', 'HandleFacebookCallback');
+    Route::get('github/callback', 'HandleGithubCallback');
 
+    // Group route dengan prefix 'auth' dan middleware 'auth:web'
+    Route::prefix('auth')->middleware(['auth:web'])->group(function () {
+        Route::get('redirect', 'LocalRedirect')->name('redirect');
+        Route::get('callback', 'LocalCallback')->name('callback');
+    });
 
-
-// Route untuk menampilkan halaman login
-Route::get('/auth/login', function () {
-    return view('auth.login');
-})->name('login');
-
-// Route untuk proses login
-Route::post('/auth/login', function (Request $request) {
-    $credentials = $request->validate([
-        'email'    => 'required',
-        'password' => 'required',
-    ]);
-
-    if (Auth::attempt($credentials)) {
-        // $request->session()->regenerate();
-
-        // dd($request->all());
-        // Regenerate session ID untuk keamanan
-        return redirect()->intended('/auth/redirect');
-    }
-
-    return back()->withErrors([
-        'email' => 'Email atau password salah',
-    ]);
-})->name('login.submit');
-
-Route::prefix('auth')->middleware(['auth'])->group(function () {
-    // Endpoint inisiasi: simpan state dan code_verifier, lalu redirect ke Passport authorization endpoint
-    Route::get('/redirect', function (Request $request) {
-        // Simpan nilai state dan code_verifier ke session (disimpan di database atau storage session lain)
-        $state = Str::random(10);
-        $codeVerifier = Str::random(128);
-        $request->session()->put('state', $state);
-        $request->session()->put('code_verifier', $codeVerifier);
-
-        // Buat code_challenge dari code_verifier
-        $codeChallenge = strtr(
-            rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='),
-            '+/',
-            '-_'
-        );
-
-        // Siapkan parameter query untuk redirect ke /oauth/authorize
-        $query = http_build_query([
-            'client_id'             => '1',
-            'redirect_uri'          => 'http://fe.org/callback.php', // Callback URL di FE.org
-            'response_type'         => 'code',
-            'scope'                 => '', // sesuaikan scope jika perlu
-            'state'                 => $state,
-            'code_challenge'        => $codeChallenge,
-            'code_challenge_method' => 'S256',
-            'prompt'                => 'consent', // Memaksa login, bisa diubah jika tidak diinginkan
-        ]);
-
-        return redirect(url('/oauth/authorize?' . $query));
-    })->name('redirect');
-
-    // Endpoint callback: menukarkan authorization code dengan token
-    Route::get('/callback', function (Request $request) {
-        // Ambil nilai state dan code_verifier yang disimpan di session
-        $storedState = $request->session()->pull("state");
-        $codeVerifier = $request->session()->pull("code_verifier");
-        Log::info($storedState . "  |=|     " . $request->state . "   0-0     " . $codeVerifier . "  |=|     " . $request->code);
-
-        // Validasi state untuk mencegah CSRF
-        throw_unless(
-            strlen($storedState) > 0 && $storedState === $request->state,
-            \InvalidArgumentException::class,
-            'Invalid state value.'
-        );
-
-        // Tukar authorization code dengan token dari endpoint OAuth token
-        $response = Http::asForm()->post(url('/oauth/token'), [
-            'grant_type'    => 'authorization_code',
-            'client_id'     => '1',
-            'redirect_uri'  => 'http://fe.org/callback.php',
-            'code_verifier' => $codeVerifier,
-            'code'          => $request->code, // gunakan authorization code yang benar
-        ]);
-        // return $response;
-        // Jika terjadi error pada response token, tangani dengan mengembalikan error message
-        if (!$response->successful()) {
-            // dd($response);
-            return response()->json(['error' => 'Token exchange failed'], $response->status());
-        }
-
-        $response = $response->json();
-        // protected string $name,
-        // protected ?string $value = null,
-        // int|string|\DateTimeInterface $expire = 0,
-        // ?string $path = '/',
-        // protected ?string $domain = null,
-        // protected ?bool $secure = null,
-        // protected bool $httpOnly = true,
-        // private bool $raw = false,
-        // ?string $sameSite = self::SAMESITE_LAX,
-        // private bool $partitioned = false,
-        // return $response;
-        $accessToken  = rawurldecode($response['access_token']);
-        $refreshToken = rawurldecode($response['refresh_token']);
-        $expiresIn    = env("PASSPORT_REFRESH") * 60 ; // second
-
-        // Redirect ke FE dengan parameter token yang sudah "mentah"
-        return redirect("http://fe.org/callback.php?access_token={$accessToken}&refresh_token={$refreshToken}&expires_in={$expiresIn}");
-    })->name('callback');
-});
-
-Route::get('/callback', function () {
-    $code = $_GET['code'];
-    $state = $_GET['state'];
-    return redirect("http://laravel.org/auth/callback?code={$code}&state={$state}");
-});
-
-Route::get("/data", function (Request $request) {
-    return view("api.users");
+    
 });


### PR DESCRIPTION
Update README.md for Socialite Authentication Integration

- Added detailed instructions for integrating external OAuth providers with Laravel Socialite.
- Documented prerequisites (API credentials, registered callback URI) and configuration steps.
- Explained the use of Laravel Passport alongside Socialite for managing OAuth 2.0 flows.
- Included guidance on using the `with()` method (e.g., `select_account` prompt) to force re-login.
- Outlined potential future enhancements such as PKCE with OTP integration and dynamic callback pages.